### PR TITLE
Specify BESST networkx module dependency to version 1.11.

### DIFF
--- a/bin/gatb-minia-pipeline/Dockerfile
+++ b/bin/gatb-minia-pipeline/Dockerfile
@@ -8,7 +8,7 @@ RUN micromamba install -y -n base -c bioconda -c conda-forge -c defaults \
 	pysam=0.8.3 \
 	bwa \
 	samtools \
-	networkx=1.9 && \
+	networkx=1.11 && \
 	micromamba clean --all --yes
 RUN git clone --recursive https://github.com/GATB/gatb-minia-pipeline .
 


### PR DESCRIPTION
Previous version was any networkx version larger than 1.9. It turns out that BESST was compatible to version 1.x.
For reference, this is resolved in the following issue link:
https://github.com/ksahlin/BESST/issues/75