### PR TITLE
Add BESST matplotlib module dependency.

### DIFF
--- a/bin/gatb-minia-pipeline/Dockerfile
+++ b/bin/gatb-minia-pipeline/Dockerfile
@@ -8,7 +8,8 @@ RUN micromamba install -y -n base -c bioconda -c conda-forge -c defaults \
 	pysam=0.8.3 \
 	bwa \
 	samtools \
-	networkx=1.11 && \
+	networkx=1.11 \
+	matplotlib=1.5 && \
 	micromamba clean --all --yes
 RUN git clone --recursive https://github.com/GATB/gatb-minia-pipeline .
 


### PR DESCRIPTION
Adding matplotlib module as one of BESST dependency. This requirement was not stated in the bioconda recipe or the gihub page for BESST.