### PR TITLE
Perform quast assessment on genome assembly output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,17 @@ DOCKER_FASTQC = $(DOCKER) quay.io/biocontainers/fastqc:0.11.9--hdfd78af_1
 DOCKER_KMC = $(DOCKER) quay.io/biocontainers/kmc:3.1.2rc1--h2d02072_0
 DOCKER_TRIMMOMATIC = $(DOCKER) quay.io/gitobioinformatics/trimmomatic:0.38
 DOCKER_GATB_PIPELINE = docker run --rm -v $$(pwd):/tmp/project -w /tmp/project agria.analytica/gatb-minia-pipeline:9d56f42
+DOCKER_QUAST = $(DOCKER) -v $$(pwd)/../ref-genomes/Arhypogaea/var.Tifrunner:/project/genome agria.analytica/quast:5.0.2
 
 DIRS = results results/fastx results/fastqc \
        results/kmc results/kmc/tmp \
 	   results/trimmomatic \
-	   results/gatb-pipeline
+	   results/gatb-pipeline \
+	   results/quast
 DATA = data/X401SC21062291-Z01-F001/raw_data/KL/KL_DDSW210004672-1a_HCKFTDSX2_L1_1.fq.gz \
        data/X401SC21062291-Z01-F001/raw_data/KL/KL_DDSW210004672-1a_HCKFTDSX2_L1_2.fq.gz
 
-all: $(DIRS) qc trimmomatic genomescope gatb-pipeline
+all: $(DIRS) qc trimmomatic genomescope gatb-pipeline quast
 
 $(DIRS): 
 	[ -d $@ ] || mkdir $@
@@ -77,4 +79,18 @@ gatb-pipeline: results/gatb-pipeline/kacang-lurik.assembly.fasta
 results/gatb-pipeline/kacang-lurik.assembly.fasta: $(TRIM_FASTQ_PAIRED1) $(TRIM_FASTQ_PAIRED2)
 	$(DOCKER_GATB_PIPELINE) /bin/bash -c "cd $(dir $@) && ../../../gatb -1 ../../$(TRIM_FASTQ_PAIRED1) -2 ../../$(TRIM_FASTQ_PAIRED2) -o $(notdir $(basename $@)) --nb-cores 7 --abundance-mins 10" 
 
-
+# assembly assessment using quast.
+REF_AHYPOGAEA = genome/arahy.Tifrunner.gnm2.J5K5.genome_main.fna
+REF_AHYPOGAEA_GFF = genome/arahy.Tifrunner.gnm2.ann1.4K0L.gene_models_main.gff3
+ASSEMBLY = results/gatb-pipeline/kacang-lurik.assembly_k21.contigs.fa \
+           results/gatb-pipeline/kacang-lurik.assembly_k41.contigs.fa \
+		   results/gatb-pipeline/kacang-lurik.assembly_k61.contigs.fa \
+		   results/gatb-pipeline/kacang-lurik.assembly_k81.contigs.fa \
+		   results/gatb-pipeline/kacang-lurik.assembly_k101.contigs.fa \
+		   results/gatb-pipeline/kacang-lurik.assembly_k121.contigs.fa \
+		   results/gatb-pipeline/kacang-lurik.assembly_k141.contigs.fa \
+		   results/gatb-pipeline/kacang-lurik.assembly.fasta
+ASSEMBLY_NAME = k21,k41,k61,k81,k101,k121,k141,k141-scaffold
+quast: results/gatb-pipeline/kacang-lurik.assembly.fasta
+	$(DOCKER_QUAST) quast.py -o results/quast -t 8 --large -r $(REF_AHYPOGAEA) --features $(REF_AHYPOGAEA_GFF) -l $(ASSEMBLY_NAME) \
+	--min-contig 500 $(ASSEMBLY)

--- a/bin/quast/Dockerfile
+++ b/bin/quast/Dockerfile
@@ -1,0 +1,5 @@
+FROM mambaorg/micromamba:0.15.3
+RUN micromamba install -y -n base -c bioconda -c conda-forge -c default \
+	quast=5.0.2 && \
+	micromamba clean --all --yes
+

--- a/bin/quast/Makefile
+++ b/bin/quast/Makefile
@@ -1,0 +1,2 @@
+all:
+	docker build -t agria.analytica/quast:5.0.2 .


### PR DESCRIPTION
Perform quast assessment post assembly with the gatb-minia pipeline to better assess the progression of the genome assembly
through different k-mer size and scaffolding steps.